### PR TITLE
fix(number-comparison): Fixed number comparison.

### DIFF
--- a/subset.go
+++ b/subset.go
@@ -3,7 +3,9 @@
 package subset
 
 import (
+	"fmt"
 	"reflect"
+	"strconv"
 )
 
 // During checkSubset, must keep track of checks that are
@@ -46,6 +48,17 @@ func checkSubset(expected, target reflect.Value, visited map[uintptr]*visit, dep
 		// fmt.Println("!target.IsValid()")
 		return false
 	}
+
+	switch expected.Kind() {
+	case reflect.Int:
+		if target.Kind() == reflect.Float64 {
+			targetValue := fmt.Sprintf("%.0f", safeInterface(target).(float64))
+			if i, err := strconv.Atoi(targetValue); err == nil {
+				target = reflect.ValueOf(i)
+			}
+		}
+	}
+
 	if expected.Type() != target.Type() {
 		// fmt.Println("Type() differs")
 		return false

--- a/subset.go
+++ b/subset.go
@@ -49,6 +49,7 @@ func checkSubset(expected, target reflect.Value, visited map[uintptr]*visit, dep
 		return false
 	}
 
+	// This enables number comparison for attribute value's
 	if (expected.Kind() == reflect.Int) && (target.Kind() == reflect.Float64) {
 		targetValue := fmt.Sprintf("%.0f", safeInterface(target).(float64))
 		if i, err := strconv.Atoi(targetValue); err == nil {

--- a/subset.go
+++ b/subset.go
@@ -49,13 +49,10 @@ func checkSubset(expected, target reflect.Value, visited map[uintptr]*visit, dep
 		return false
 	}
 
-	switch expected.Kind() {
-	case reflect.Int:
-		if target.Kind() == reflect.Float64 {
-			targetValue := fmt.Sprintf("%.0f", safeInterface(target).(float64))
-			if i, err := strconv.Atoi(targetValue); err == nil {
-				target = reflect.ValueOf(i)
-			}
+	if (expected.Kind() == reflect.Int) && (target.Kind() == reflect.Float64) {
+		targetValue := fmt.Sprintf("%.0f", safeInterface(target).(float64))
+		if i, err := strconv.Atoi(targetValue); err == nil {
+			target = reflect.ValueOf(i)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Fixed an issue where json unmarshal of actual dispatched-events to `[]map[string]interface{}` caused all `int` values to convert to `float64` which resulted in comparison failure.

